### PR TITLE
Embed target and protein with pretrained model

### DIFF
--- a/datamodules.py
+++ b/datamodules.py
@@ -177,6 +177,31 @@ class ContrastiveDataset(Dataset):
 
         return anchorEmb, positiveEmb, negativeEmb
 
+class EmbedDataset(Dataset):
+    def __init__(
+        self,
+        data_file: str,
+        moltype: str,
+        drug_featurizer: Featurizer,
+        target_featurizer: Featurizer,
+    ):
+        self.data = pd.read_csv(data_file, sep="\t", header=None)
+        self.moltype = moltype
+
+        self.drug_featurizer = drug_featurizer
+        self.target_featurizer = target_featurizer
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, i):
+        if self.moltype == "drug":
+            mol = self.drug_featurizer(self.data.iloc[i, 0])
+        elif self.moltype == "target":
+            mol = self.target_featurizer(self.data.iloc[i, 0])
+
+        return mol
+
 class DTIDataModule(pl.LightningDataModule):
     """ DataModule used for training on drug-target interaction data.
     Uses the following data sets:

--- a/datamodules.py
+++ b/datamodules.py
@@ -207,20 +207,22 @@ class EmbedDataset(Dataset):
         drug_featurizer: Featurizer,
         target_featurizer: Featurizer,
     ):
-        self.data = pd.read_csv(data_file, sep="\t", header=None)
+        self.data = pd.read_table(data_file, header=0)
         self.moltype = moltype
 
         self.drug_featurizer = drug_featurizer
         self.target_featurizer = target_featurizer
+
+        self._column = "SMILES" if self.moltype == "drug" else "Target Sequence"
 
     def __len__(self):
         return len(self.data)
 
     def __getitem__(self, i):
         if self.moltype == "drug":
-            mol = self.drug_featurizer(self.data.iloc[i, 0])
+            mol = self.drug_featurizer(self.data[self._column].iloc[i])
         elif self.moltype == "target":
-            mol = self.target_featurizer(self.data.iloc[i, 0])
+            mol = self.target_featurizer(self.data[self._column].iloc[i])
 
         return mol
 

--- a/datamodules.py
+++ b/datamodules.py
@@ -40,6 +40,28 @@ def get_task_dir(task_name: str):
 
     return Path(task_paths[task_name.lower()]).resolve()
 
+def embed_collate_fn(args: T.Tuple[torch.Tensor, torch.Tensor], moltype="target"):
+    """
+    Collate function for PyTorch data loader -- turn a batch of molecules into a batch of tensors
+
+    :param args: Batch of molecules
+    :type args: Iterable[Tuple[torch.Tensor, torch.Tensor]]
+    :param moltype: Molecule type
+    :type moltype: str
+    :return: Create a batch of examples
+    :rtype: torch.Tensor
+    """
+    # m_emb = [a for a in args]
+
+    if moltype == "drug":
+        mols = torch.stack(args, 0)
+    elif moltype == "target":
+        mols = pad_sequence(args, batch_first=True)
+    else:
+        raise ValueError("moltype must be one of ['drug', 'target']")
+
+    return mols
+
 def drug_target_collate_fn(args: T.Tuple[torch.Tensor, torch.Tensor, torch.Tensor]):
     """
     Collate function for PyTorch data loader -- turn a batch of triplets into a triplet of batches

--- a/embed.py
+++ b/embed.py
@@ -1,11 +1,12 @@
 import os
 import argparse
+from functools import partial
 import torch
 from tqdm import tqdm
 import numpy as np
 import pandas as pd
 from torch.utils.data import DataLoader
-from datamodules import EmbedDataset
+from datamodules import EmbedDataset, embed_collate_fn
 from model import DrugTargetCoembeddingLightning
 from utils import get_featurizer
 
@@ -13,9 +14,6 @@ def get_args():
     parser = argparse.ArgumentParser(description='Generate embeddings from DrugTargetCoembeddingLightning model')
     parser.add_argument('--data-file', type=str, required=True, help='Path to file containing molecules to embed')
     parser.add_argument("--moltype", type=str, help="Molecule type", choices=["drug", "target"], default="target")
-
-    parser.add_argument("--drug-featurizer", help="Drug featurizer", dest="drug_featurizer", default="MorganFeaturizer")
-    parser.add_argument("--target-featurizer", help="Target featurizer", dest="target_featurizer", default="ESM2Featurizer")
 
     parser.add_argument('--checkpoint', type=str, required=True, help='Path to model checkpoint')
     parser.add_argument('--output_path', type=str, required=True, help='path to save embeddings. Currently only supports numpy format.')
@@ -26,28 +24,31 @@ def get_args():
 if __name__ == '__main__':
     args = get_args()
 
-    drug_featurizer = get_featurizer(args.drug_featurizer)
-    target_featurizer = get_featurizer(args.target_featurizer)
-
     model = DrugTargetCoembeddingLightning.load_from_checkpoint(args.checkpoint)
     model.eval()
     use_cuda = torch.cuda.is_available()
     device = torch.device(f"cuda:{args.device}") if use_cuda else torch.device("cpu")
     model.to(device)
     
+    drug_featurizer = get_featurizer(model.args.drug_featurizer)
+    target_featurizer = get_featurizer(model.args.target_featurizer)
+
     dataset = EmbedDataset(args.data_file, args.moltype, drug_featurizer, target_featurizer)
 
-    dataloader = DataLoader(dataset, batch_size=args.batch_size, shuffle=False)
+    collate_fn = partial(embed_collate_fn, moltype=args.moltype)
+    dataloader = DataLoader(dataset, batch_size=args.batch_size, shuffle=False, collate_fn=collate_fn)
 
     embeddings = []
     with torch.no_grad():
-        for mols in tqdm(dataloader):
+        for mols in tqdm(dataloader, desc="Embedding", total=len(dataloader)):
             mols = mols.to(device)
             emb = model.embed(mols, sample_type=args.moltype)
             embeddings.append(emb.cpu().numpy())
     embeddings = np.concatenate(embeddings, axis=0)
 
-    os.makedirs(os.path.dirname(args.output_path), exist_ok=True)
+    # if output_path contains directories that do not exist, create them
+    if os.path.dirname(args.output_path) != '' and not os.path.exists(os.path.dirname(args.output_path)):
+        os.makedirs(os.path.dirname(args.output_path))
 
     np.save(args.output_path, embeddings)
 

--- a/embed.py
+++ b/embed.py
@@ -12,7 +12,7 @@ from utils import get_featurizer
 
 def get_args():
     parser = argparse.ArgumentParser(description='Generate embeddings from DrugTargetCoembeddingLightning model')
-    parser.add_argument('--data-file', type=str, required=True, help='Path to file containing molecules to embed')
+    parser.add_argument('--data-file', type=str, required=True, help='Path to file containing molecules to embed, in tsv format. With header and columns: "SMILES" for drugs, "Target Sequence" for targets')
     parser.add_argument("--moltype", type=str, help="Molecule type", choices=["drug", "target"], default="target")
 
     parser.add_argument('--checkpoint', type=str, required=True, help='Path to model checkpoint')

--- a/embed.py
+++ b/embed.py
@@ -1,8 +1,3 @@
-# Script to generate embeddings from the DrugTargetCoembeddingLightning model
-# Input will be a list of drug smiles and target sequences
-# Output will be the embeddings of the drugs and targets
-#
-
 import os
 import argparse
 import torch
@@ -13,7 +8,6 @@ from torch.utils.data import DataLoader
 from datamodules import EmbedDataset
 from model import DrugTargetCoembeddingLightning
 from utils import get_featurizer
-from drug_target_embed.config import Config
 
 def get_args():
     parser = argparse.ArgumentParser(description='Generate embeddings from DrugTargetCoembeddingLightning model')
@@ -24,7 +18,7 @@ def get_args():
     parser.add_argument("--target-featurizer", help="Target featurizer", dest="target_featurizer", default="ESM2Featurizer")
 
     parser.add_argument('--checkpoint', type=str, help='Path to model checkpoint')
-    parser.add_argument('--output_path', type=str, help='path to save embeddings')
+    parser.add_argument('--output_path', type=str, help='path to save embeddings. Currently only supports numpy format.')
     parser.add_argument('--batch_size', type=int, default=128, help='Batch size for inference')
     parser.add_argument('--device', type=str, default=0, help='CUDA device. If CUDA is not available, this will be ignored.')
     return parser.parse_args()
@@ -53,13 +47,8 @@ if __name__ == '__main__':
             embeddings.append(emb.cpu().numpy())
     embeddings = np.concatenate(embeddings, axis=0)
 
-    # make sure directories for output_path exist
     os.makedirs(os.path.dirname(args.output_path), exist_ok=True)
 
     np.save(args.output_path, embeddings)
-
-
-    
-
 
 

--- a/featurizers.py
+++ b/featurizers.py
@@ -36,11 +36,7 @@ class Featurizer:
 
     def __call__(self, seq: str) -> torch.Tensor:
         if seq not in self.features:
-            seq_h5 = sanitize_string(seq)
-            if not self._preloaded and self._h5 is not None and seq_h5 in self._h5:
-                return torch.from_numpy(self._h5[seq_h5][:])
-            else:
-                self._features[seq] = self.transform(seq)
+            self._features[seq] = self.transform(seq)
 
         return self._features[seq]
 

--- a/model.py
+++ b/model.py
@@ -392,6 +392,12 @@ class DrugTargetCoembeddingLightning(pl.LightningModule):
         self.test_step_outputs.clear()
         self.test_step_targets.clear()
 
+    def embed(self, x, sample_type="drug"):
+        if sample_type == "drug":
+            return self.drug_projector(x)
+        elif sample_type == "target":
+            return self.target_projector(x)
+
 
 def main():
     from featurizers import ProtBertFeaturizer

--- a/protbert_feat.py
+++ b/protbert_feat.py
@@ -1,0 +1,32 @@
+import argparse
+import pandas as pd
+
+from featurizers import ProtBertFeaturizer
+
+def add_args(parser: argparse.ArgumentParser):
+    parser.add_argument(
+        "--data-file",
+        type=str,
+        required=True,
+        default="./data/prots.tsv",
+        help="Path to the file containing data in CSV file format, with the protein sequence appearing as the last column. The column name should be \"Target Sequence\"",
+    )
+
+def main(data_file: str):
+    protbert = ProtBertFeaturizer()
+    out_file = data_file + ".prot.h5"
+    prot_list = []
+
+    df = pd.read_csv(data_file)
+    headers = df.columns
+    assert "Target Sequence" in headers
+
+    prot_list = df["Target Sequence"].to_list()
+
+    protbert.write_to_disk(prot_list, file_path=out_file)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    add_args(parser)
+    args = parser.parse_args()
+    main(args.data_file)

--- a/train.py
+++ b/train.py
@@ -22,7 +22,6 @@ from datamodules import (
         CombinedDataModule,
         )
 from model import DrugTargetCoembeddingLightning
-from trainloop import ConPlexEpochLoop
 from utils import get_featurizer, xavier_normal
 
 parser = argparse.ArgumentParser(description="PLM_DTI Training.")


### PR DESCRIPTION
Easy interface for embedding a tsv of protein sequences or molecule SMILES strings into the coembedding space of a pretrained model.
All you need is a model checkpoint (with the hyperparameters saved into the checkpoint file) and a tsv you want to embed.

Embedded proteins or molecules are returned as a numpy file.