### PR TITLE
ProtBert handles extra keyword arguments

### DIFF
--- a/ultrafast/featurizers.py
+++ b/ultrafast/featurizers.py
@@ -320,7 +320,7 @@ class MorganFeaturizer(Featurizer):
             return torch.stack(all_feats, dim=0)
 
 class ProtBertFeaturizer(Featurizer):
-    def __init__(self, save_dir: Path = Path().absolute(), per_tok=False):
+    def __init__(self, save_dir: Path = Path().absolute(), per_tok=False, **kwargs):
         super().__init__("ProtBert", 1024, save_dir)
 
 


### PR DESCRIPTION
Previously there was an Error when training a protbert model and using it for embedding:
```
TypeError: ProtBertFeaturizer.__init__() got an unexpected keyword argument 'batch_size'
```
This is due to how ESM2 and SaProt handle batched featurization, but this is not implemented in ProtBertFeaturizer. Therefore, I have added a kwarg to ProtBert to handle key word arguments that other featurizers may use but it does not.