### PR TITLE
All Featurizers can use LMDB

### DIFF
--- a/ultrafast/datamodules.py
+++ b/ultrafast/datamodules.py
@@ -265,7 +265,7 @@ class EmbedDataset(Dataset):
 
         return mol
 
-    def teardown(self):
+    def teardown(self, stage):
         if self.db is not None:
             self.db.close()
 
@@ -411,11 +411,9 @@ class DTIDataModule(pl.LightningDataModule):
     def test_dataloader(self):
         return DataLoader(self.data_test, **self._loader_kwargs)
 
-    def teardown(self):
-        if self.drug_db is not None:
-            self.drug_db.close()
-        if self.target_db is not None:
-            self.target_db.close()
+    def teardown(self, stage):
+        self.drug_featurizer.teardown(stage)
+        self.target_featurizer.teardown(stage)
 
 class DTIStructDataModule(DTIDataModule):
     """ DataModule used for training on drug-target interaction data.

--- a/ultrafast/datamodules.py
+++ b/ultrafast/datamodules.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import torch
 import os
+import hashlib
 
 import numpy as np
 import pandas as pd
@@ -319,6 +320,8 @@ class DTIDataModule(pl.LightningDataModule):
         self.drug_featurizer = drug_featurizer
         self.target_featurizer = target_featurizer
 
+        self.drug_db, self.target_db = None, None
+
     def prepare_data(self):
         """
         Featurize drugs and targets and save them to disk if they don't already exist
@@ -407,6 +410,12 @@ class DTIDataModule(pl.LightningDataModule):
 
     def test_dataloader(self):
         return DataLoader(self.data_test, **self._loader_kwargs)
+
+    def teardown(self):
+        if self.drug_db is not None:
+            self.drug_db.close()
+        if self.target_db is not None:
+            self.target_db.close()
 
 class DTIStructDataModule(DTIDataModule):
     """ DataModule used for training on drug-target interaction data.

--- a/ultrafast/datamodules.py
+++ b/ultrafast/datamodules.py
@@ -411,7 +411,7 @@ class DTIDataModule(pl.LightningDataModule):
     def test_dataloader(self):
         return DataLoader(self.data_test, **self._loader_kwargs)
 
-    def teardown(self, stage):
+    def teardown(self, stage:str):
         self.drug_featurizer.teardown(stage)
         self.target_featurizer.teardown(stage)
 

--- a/ultrafast/featurizers.py
+++ b/ultrafast/featurizers.py
@@ -370,7 +370,7 @@ class Featurizer:
 
         torch.cuda.empty_cache()
 
-    def teardown(self):
+    def teardown(self, stage: str):
         if hasattr(self, 'db') and self.db is not None:
             self.db.close()
 

--- a/ultrafast/featurizers.py
+++ b/ultrafast/featurizers.py
@@ -62,6 +62,7 @@ class Featurizer:
         self._batch_size = batch_size
 
         self.id_to_idx = None
+        self.ext = ext
         self._map_size = 10000
         if ext == 'lmdb' and 'map_size' in kwargs and kwargs['map_size'] is not None:
             self._map_size = kwargs['map_size']
@@ -317,7 +318,8 @@ class Featurizer:
             elif self.moltype == "target":
                 for seq, results in zip(batch_ids, feats):
                     seq_data = results.numpy()[np.newaxis, ...]
-                    db.put_samples('ids', seq, 'feats', seq_data)
+                    seq_arr = np.array(seq)[np.newaxis, ...]
+                    db.put_samples('ids', seq_arr, 'feats', seq_data)
         db.close()
 
         print(f"Processed and stored {len(sorted_ids)} {self.moltype} {'fingerprints' if self.moltype == 'drug' else 'sequences'} in LMDB.")


### PR DESCRIPTION
Now a datamodule agnostic use of LMDB. 

All that needs to be done is setting `ext='lmdb'` during initialization of the `Featurizer`.
Uses the MD5 hash of the sequence (SMILES or protein sequence) to index the sequence in the LMDB for cheaper storage of keys in the sequence -> index dictionary.

When saving the LMDB for later use, need to save both the LMDB and the `{self.name}_id_to_idx.npy`.