### PR TITLE
AIDO.Protein2StructureToken featurizer and benchmark results across Table 1 datasets

### DIFF
--- a/utils/sprint_aido.py
+++ b/utils/sprint_aido.py
@@ -1,0 +1,30 @@
+import subprocess
+
+WANDB_PROJ = "SPRINT-AIDO"
+CONFIG = "configs/saprot_agg_config.yaml"
+EPOCHS = 20
+
+# Tasks: davis, bindingdb, biosnap, biosnap_prot, biosnap_mol, merged
+TASKS = ["davis", "bindingdb", "biosnap", "biosnap_prot", "biosnap_mol", "merged"]
+SIZE = "large"   # Only large models
+REPS = [0, 1, 2, 3, 4]
+
+for task in TASKS:
+    for r in REPS:
+        exp_id = f"{task.upper()}_AIDO_{SIZE}_R{r}"
+        print(f"=== Running {exp_id} ===")
+
+        cmd = [
+            "ultrafast-train",
+            "--exp-id", exp_id,
+            "--task", task,
+            "--config", CONFIG,
+            "--target-featurizer", "AIDO_P2ST16B",
+            "--prot-proj", "agg",
+            "--model-size", SIZE,
+            "--replicate", str(r),
+            "--epochs", str(EPOCHS),
+            "--wandb-proj", WANDB_PROJ
+        ]
+
+        subprocess.run(cmd, check=True)


### PR DESCRIPTION
- Added support for the AIDOProtein2StructureTokenFeaturizer in featurizers.py
- Evaluated its performance in the SPRINT (16M) framework.
- Ran benchmarks across all datasets from Table 1 (DAVIS, BindingDB, BIOSNAP full, BIOSNAP unseen targets, BIOSNAP unseen drugs, and MERGED) with 5 replicates each.
- Logged experiments to Weights & Biases for reproducibility.


### **Results (Test AUPR)**


<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/nonso/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/nonso/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
.font5
	{color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{text-align:center;}
-->

</head>

<body link="#467886" vlink="#96607D">


Models | ConPlex | ConPlex-attn* | SPRINT-sm (10M) | SPRINT (16M) | SPRINT (16M)
-- | -- | -- | -- | -- | --
Backbone Pooling | ProtBert Avg | ProtBert Attn | SaProt Attn | SaProt Attn | AIDO.Protein2Structure
BIOSNAP | 0.883±0.004 | 0.904±0.005 | 0.936±0.001 | 0.858±0.001 | 0.862   ± 0.005
Unseen Drugs | 0.874±0.002 | 0.905±0.002 | 0.906±0.001 | 0.851±0.002 | 0.883±0.005
Unseen Targets | 0.842±0.006 | 0.844±0.011 | 0.849±0.006 | 0.793±0.007 | 0.769 ± 0.005
DAVIS | 0.457±0.037 | 0.493±0.014 | 0.507±0.005 | 0.446±0.003 | 0.276 ± 0.007
BindingDB | 0.616±0.009 | 0.672±0.003 | 0.718±0.0004 | 0.588±0.0006 | 0.610 ± 0.008
MERGED | 0.414±0.004 | 0.448±0.018 | 0.481±0.004 | 0.526±0.002 | 0.449 ± 0.012



</body>

</html>

### **Notes**

- Each entry reports mean ± std across 5 replicates.
- Checkpoints were selected based on the best validation AUPR.
- WandB logs for all experiments are available [here](https://wandb.ai/nonsoduaka821-grambling-state-university/SPRINT-AIDO/table?nw=nwusernonsoduaka821)
- To replicate this, go to sprint_aido.py, located in utils, a Python script that automates the replication process.