### PR TITLE
Add MoLFormer and MoLFormerSeq Featurizers

### DIFF
--- a/ultrafast/featurizers.py
+++ b/ultrafast/featurizers.py
@@ -475,6 +475,16 @@ class MorganFeaturizer(Featurizer):
             ]
             return torch.stack(all_feats, dim=0)
 
+class MoLFormerFeaturizer(Featurizer):
+    def __init__(self, shape: int = 768, save_dir: Path = Path().absolute(), ext: str = "lmdb", batch_size: int = 32, n_jobs=-1):
+        super().__init__("MoLFormer", shape, "drug", save_dir, ext, batch_size)
+
+    def _transform_single(self, smile: str) -> torch.Tensor:
+        raise NotImplementedError("Precompute the lmdb for the MoLFormer embeddings")
+
+    def _transform(self, batch_smiles: List[str]) -> torch.Tensor:
+        raise NotImplementedError("Precompute the lmdb for the MoLFormer embeddings")
+
 class ProtBertFeaturizer(Featurizer):
     def __init__(self, save_dir: Path = Path().absolute(), per_tok=False, **kwargs):
         super().__init__("ProtBert", 1024, "target", save_dir, **kwargs)

--- a/ultrafast/model.py
+++ b/ultrafast/model.py
@@ -67,10 +67,17 @@ class DrugTargetCoembeddingLightning(pl.LightningModule):
         self.contrastive = contrastive
         self.args = args
 
-        self.drug_projector = nn.Sequential(
-            nn.Linear(self.drug_dim, self.latent_dim), self.activation()
-        )
-        nn.init.xavier_normal_(self.drug_projector[0].weight)
+        if 'Seq' not in args.drug_featurizer:
+            self.drug_projector = nn.Sequential(
+                nn.Linear(self.drug_dim, self.latent_dim), self.activation()
+            )
+            nn.init.xavier_normal_(self.drug_projector[0].weight)
+        else:
+            self.drug_projector = nn.Sequential(
+                    Learned_Aggregation_Layer(self.drug_dim, num_heads=self.args.num_heads_agg, attn_drop=dropout, proj_drop=dropout),
+                    nn.Linear(self.drug_dim, self.latent_dim),
+                    self.activation()
+                    )
 
         if prot_proj == "avg":
             protein_projector=nn.Sequential(AverageNonZeroVectors(), nn.Linear(self.target_dim, self.latent_dim))

--- a/utils/MoLFormer_Embed/README.md
+++ b/utils/MoLFormer_Embed/README.md
@@ -1,0 +1,15 @@
+# MoLFormer
+[MoLFormer](https://github.com/IBM/molformer) is a chemical language model for generating representations of small molecules from their SMILES strings.
+
+## Generating MoLFormer embeddings to train SPRINT
+1. Follow the instructions in [MoLFormer's environment.md](https://github.com/IBM/molformer/blob/main/environment.md) to setup a new environment (distinct from the SPRINT environment) for running MoLFormer.
+
+2. Download the pretrained checkpoint of MoLFormer from [IBM's Box](https://ibm.box.com/v/MoLFormer-data) into this directory.
+
+3. Download all of the files and folders in [molformer/notebooks/pretrained_molformer](https://github.com/IBM/molformer/tree/main/notebooks/pretrained_molformer) into this folder.
+
+4. Run `molformer_embed.py`, making sure to set the `--csv-dir` to the directory containing train.csv, val.csv, and test.csv. It will use the pretrained MoLFormer model to generate embeddings for all of the molecules in the csvs and generate a lmdb directory that can be used during normal SPRINT training. 
+
+## Running a SPRINT model on MoLFormer embeddings
+
+Once you have generated the embeddings using the above procedure all you need to do when training is specify: `--drug-featurizer MoLFormerFeaturizer` on the commandline and it will use the pre-computed embeddings in the lmdb for training.

--- a/utils/MoLFormer_Embed/molformer_embed.py
+++ b/utils/MoLFormer_Embed/molformer_embed.py
@@ -1,0 +1,92 @@
+#/usr/bin/python3
+import yaml
+import hashlib
+
+from argparse import Namespace, ArgumentParser
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import pyxis as px
+import torch
+
+from fast_transformers.masking import LengthMask as LM
+from tqdm import tqdm
+from rdkit import Chem
+
+from tokenizer.tokenizer import MolTranBertTokenizer
+from train_pubchem_light import LightningModule
+
+def canonicalize(s):
+    return Chem.MolToSmiles(Chem.MolFromSmiles(s, sanitize=False), canonical=True, isomericSmiles=False)
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument('--csv-dir','-C',required=True,help='directory containing train/val/test csvs to embed')
+    parser.add_argument('--batch-size', type=int, default=128, help='batch size for running MoLFormer')
+    parser.add_argument('--map-size-limit', type=int, default=10000 , help='Size limit in MB of the LMDB')
+    parser.add_argument('--save-all',action="store_true",help="Save all tokens, instead of each token")
+    args = parser.parse_args()
+
+    csv_dir = Path(args.csv_dir).absolute()
+    if not csv_dir.is_dir():
+        raise ValueError(f"csv-dir is not a directory: {csv_dir}")
+
+    with open('hparams.yaml', 'r') as f:
+        config = Namespace(**yaml.safe_load(f))
+
+    tokenizer = MolTranBertTokenizer('bert_vocab.txt')
+
+    ckpt = 'N-Step-Checkpoint_3_30000.ckpt'
+    name = "MoLFormerSeq" if args.save_all else "MoLFormer"
+
+    lm = LightningModule(config, tokenizer.vocab).load_from_checkpoint(ckpt, config=config, vocab=tokenizer.vocab)
+    lm = lm.to('cuda') if torch.cuda.is_available() else lm.to('cpu')
+
+    if 'MERGED' not in str(csv_dir):
+        seq_list = set()
+        for csvs in ["train","val","test"]:
+            seq_df = pd.read_csv(csv_dir / Path(f"{csvs}.csv"))
+            seq_list |= set(seq_df['SMILES'].to_list())
+
+        seq_dict = {hashlib.md5(seq.encode()).hexdigest(): seq for seq in seq_list}
+        sorted_ids = sorted(seq_dict.keys())
+        id_to_idx = {seq: idx for idx, seq in enumerate(sorted_ids)}
+        np.save(csv_dir / Path(f'{name}_id_to_idx.npy'), id_to_idx)
+    else:
+        seq_dict = np.load(csv_dir / 'id_to_smiles.npy', allow_pickle=True).item()
+        sorted_ids = sorted(seq_dict.keys())
+
+    lmdb_path = f'{name}_features.lmdb'
+        
+    db = px.Writer(dirpath=str(csv_dir / Path(lmdb_path)), map_size_limit=args.map_size_limit, ram_gb_limit=10)
+
+    lm.eval()
+    batch_size = args.batch_size
+    for i in tqdm(range(0, len(sorted_ids), batch_size)):
+        batch_ids = np.array(sorted_ids[i:i+batch_size])
+        batch_seq = [canonicalize(seq_dict[idx]) for idx in batch_ids]
+
+        batch_enc = tokenizer.batch_encode_plus(batch_seq, padding=True, add_special_tokens=True)
+        idx, mask = torch.tensor(batch_enc['input_ids']).to(lm.device), torch.tensor(batch_enc['attention_mask']).to(lm.device)
+
+        with torch.no_grad():
+            token_embeddings = lm.blocks(lm.tok_emb(idx), length_mask=LM(mask.sum(-1)))
+
+        if not args.save_all:
+            # average pooling over tokens
+            input_mask_expanded = mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+            sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
+            sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+            embedding = sum_embeddings / sum_mask
+
+            db.put_samples('ids', batch_ids, 'feats', embedding.detach().cpu().numpy())
+        else:
+            for i, ids in enumerate(batch_ids):
+                seq_len = mask[i,:].squeeze().sum()
+                feats = token_embeddings[i].squeeze()[:seq_len].detach().cpu().numpy()
+
+                db.put_samples('ids', np.array(ids)[np.newaxis,...], 'feats', feats[np.newaxis,...])
+            
+    db.close()
+
+

--- a/utils/MolFormer_Embed/README.md
+++ b/utils/MolFormer_Embed/README.md
@@ -1,0 +1,15 @@
+# MoLFormer
+[MoLFormer](https://github.com/IBM/molformer) is a chemical language model for generating representations of small molecules from their SMILES strings.
+
+## Generating MoLFormer embeddings to train SPRINT
+1. Follow the instructions in [MoLFormer's environment.md](https://github.com/IBM/molformer/blob/main/environment.md) to setup a new environment (distinct from the SPRINT environment) for running MoLFormer.
+
+2. Download the pretrained checkpoint of MoLFormer from [IBM's Box](https://ibm.box.com/v/MoLFormer-data) into this directory.
+
+3. Download all of the files and folders in [molformer/notebooks/pretrained_molformer](https://github.com/IBM/molformer/tree/main/notebooks/pretrained_molformer) into this folder.
+
+4. Run `molformer_embed.py`, making sure to set the `--csv-dir` to the directory containing train.csv, val.csv, and test.csv. It will use the pretrained MoLFormer model to generate embeddings for all of the molecules in the csvs and generate a lmdb directory that can be used during normal SPRINT training. 
+
+## Running a SPRINT model on MoLFormer embeddings
+
+Once you have generated the embeddings using the above procedure all you need to do when training is specify: `--drug-featurizer MoLFormerFeaturizer` on the commandline and it will use the pre-computed embeddings in the lmdb for training.

--- a/utils/MolFormer_Embed/molformer_embed.py
+++ b/utils/MolFormer_Embed/molformer_embed.py
@@ -1,0 +1,74 @@
+#/usr/bin/python3
+import yaml
+import hashlib
+
+from argparse import Namespace, ArgumentParser
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import pyxis as px
+import torch
+
+from fast_transformers.masking import LengthMask as LM
+from tqdm import tqdm
+from rdkit import Chem
+
+from tokenizer.tokenizer import MolTranBertTokenizer
+from train_pubchem_light import LightningModule
+
+def canonicalize(s):
+    return Chem.MolToSmiles(Chem.MolFromSmiles(s, sanitize=False), canonical=True, isomericSmiles=False)
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument('--csv-dir','-C',required=True,help='directory containing train/val/test csvs to embed')
+    args = parser.parse_args()
+
+    csv_dir = Path(args.csv_dir).absolute()
+    if not csv_dir.is_dir():
+        raise ValueError(f"csv-dir is not a directory: {csv_dir}")
+    elif 'MERGED' in csv_dir:
+        raise NotImplementedError("Currently not set up for the MERGED database")
+
+    with open('hparams.yaml', 'r') as f:
+        config = Namespace(**yaml.safe_load(f))
+
+    tokenizer = MolTranBertTokenizer('bert_vocab.txt')
+
+    ckpt = 'N-Step-Checkpoint_3_30000.ckpt'
+
+    lm = LightningModule(config, tokenizer.vocab).load_from_checkpoint(ckpt, config=config, vocab=tokenizer.vocab)
+    lm = lm.to('cuda') if torch.cuda.is_available() else lm.to('cpu')
+
+    seq_list = set()
+    for csvs in ["train","val","test"]:
+        seq_df = pd.read_csv({csv_dir} / Path(f"{csvs}.csv"))
+        seq_list |= set(seq_df['SMILES'].to_list())
+
+    seq_dict = {hashlib.md5(seq.encode()).hexdigest(): seq for seq in seq_list}
+    sorted_ids = sorted(seq_dict.keys())
+    id_to_idx = {seq: idx for idx, seq in enumerate(sorted_ids)}
+    np.save(csv_dir / Path('MoLFormer_id_to_idx.npy'), id_to_idx)
+    db = px.Writer(dirpath=csv_dir / Path('MoLFormer_features.lmdb'), map_size_limit=10000, ram_gb_limit=10)
+
+    lm.eval()
+    batch_size = 64
+    for i in tqdm(range(0, len(seq_list), batch_size)):
+        batch_ids = np.array(sorted_ids[i:i+batch_size])
+        batch_seq = [canonicalize(seq_dict[idx]) for idx in batch_ids]
+
+        batch_enc = tokenizer.batch_encode_plus(batch_seq, padding=True, add_special_tokens=True)
+        idx, mask = torch.tensor(batch_enc['input_ids']).to(lm.device), torch.tensor(batch_enc['attention_mask']).to(lm.device)
+
+        with torch.no_grad():
+            token_embeddings = lm.blocks(lm.tok_emb(idx), length_mask=LM(mask.sum(-1)))
+        # average pooling over tokens
+        input_mask_expanded = mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+        sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
+        sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+        embedding = sum_embeddings / sum_mask
+
+        db.put_samples('ids', batch_ids, 'feats', embedding.detach().cpu().numpy())
+    db.close()
+
+

--- a/utils/MolFormer_Embed/molformer_embed.py
+++ b/utils/MolFormer_Embed/molformer_embed.py
@@ -22,13 +22,12 @@ def canonicalize(s):
 if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument('--csv-dir','-C',required=True,help='directory containing train/val/test csvs to embed')
+    parser.add_argument('--save-all',action="store_true",help="Save all tokens, instead of each token")
     args = parser.parse_args()
 
     csv_dir = Path(args.csv_dir).absolute()
     if not csv_dir.is_dir():
         raise ValueError(f"csv-dir is not a directory: {csv_dir}")
-    elif 'MERGED' in csv_dir:
-        raise NotImplementedError("Currently not set up for the MERGED database")
 
     with open('hparams.yaml', 'r') as f:
         config = Namespace(**yaml.safe_load(f))
@@ -40,20 +39,29 @@ if __name__ == "__main__":
     lm = LightningModule(config, tokenizer.vocab).load_from_checkpoint(ckpt, config=config, vocab=tokenizer.vocab)
     lm = lm.to('cuda') if torch.cuda.is_available() else lm.to('cpu')
 
-    seq_list = set()
-    for csvs in ["train","val","test"]:
-        seq_df = pd.read_csv({csv_dir} / Path(f"{csvs}.csv"))
-        seq_list |= set(seq_df['SMILES'].to_list())
+    if 'MERGED' not in str(csv_dir):
+        seq_list = set()
+        for csvs in ["train","val","test"]:
+            seq_df = pd.read_csv(csv_dir / Path(f"{csvs}.csv"))
+            seq_list |= set(seq_df['SMILES'].to_list())
 
-    seq_dict = {hashlib.md5(seq.encode()).hexdigest(): seq for seq in seq_list}
-    sorted_ids = sorted(seq_dict.keys())
-    id_to_idx = {seq: idx for idx, seq in enumerate(sorted_ids)}
-    np.save(csv_dir / Path('MoLFormer_id_to_idx.npy'), id_to_idx)
-    db = px.Writer(dirpath=csv_dir / Path('MoLFormer_features.lmdb'), map_size_limit=10000, ram_gb_limit=10)
+        seq_dict = {hashlib.md5(seq.encode()).hexdigest(): seq for seq in seq_list}
+        sorted_ids = sorted(seq_dict.keys())
+        id_to_idx = {seq: idx for idx, seq in enumerate(sorted_ids)}
+        np.save(csv_dir / Path('MoLFormer_id_to_idx.npy'), id_to_idx)
+    else:
+        seq_dict = np.load(csv_dir / 'id_to_smiles.npy', allow_pickle=True).item()
+        sorted_ids = sorted(seq_dict.keys())
+
+    lmdb_path = 'MoLFormer_features.lmdb'
+    if args.save_all:
+        lmdb_path = 'MoLFormerSeq_features.lmdb'
+        
+    db = px.Writer(dirpath=str(csv_dir / Path(lmdb_path)), map_size_limit=10000, ram_gb_limit=10)
 
     lm.eval()
-    batch_size = 64
-    for i in tqdm(range(0, len(seq_list), batch_size)):
+    batch_size = 512
+    for i in tqdm(range(0, len(sorted_ids), batch_size)):
         batch_ids = np.array(sorted_ids[i:i+batch_size])
         batch_seq = [canonicalize(seq_dict[idx]) for idx in batch_ids]
 
@@ -62,13 +70,22 @@ if __name__ == "__main__":
 
         with torch.no_grad():
             token_embeddings = lm.blocks(lm.tok_emb(idx), length_mask=LM(mask.sum(-1)))
-        # average pooling over tokens
-        input_mask_expanded = mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-        sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
-        sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
-        embedding = sum_embeddings / sum_mask
 
-        db.put_samples('ids', batch_ids, 'feats', embedding.detach().cpu().numpy())
+        if not args.save_all:
+            # average pooling over tokens
+            input_mask_expanded = mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+            sum_embeddings = torch.sum(token_embeddings * input_mask_expanded, 1)
+            sum_mask = torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+            embedding = sum_embeddings / sum_mask
+
+            db.put_samples('ids', batch_ids, 'feats', embedding.detach().cpu().numpy())
+        else:
+            for i, ids in enumerate(batch_ids):
+                seq_len = mask[i,:].squeeze().sum()
+                feats = token_embeddings[i].squeeze()[:seq_len].detach().cpu().numpy()
+
+                db.put_samples('ids', np.array(ids)[np.newaxis,...], 'feats', feats[np.newaxis,...])
+            
     db.close()
 
 


### PR DESCRIPTION
Adds a featurizer using the [MoLFormer](https://github.com/IBM/molformer) language model

Featurization needs to be done before running SPRINT in a different environment due to package incompatibility issues. A README and script for generating the features are found in `utils/MoLFormer_Embed`.

Sets up a new collate function and model setup to allow using the output sequence from MoLFormer as the molecule embedding with LearnedAgg, rather than the average of the molecule sequence.